### PR TITLE
Better handling of HnR for leeching torrents

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -93,7 +93,6 @@ type Database struct {
 	UsersMutex sync.RWMutex
 	
 	HitAndRuns      map[UserTorrentPair]struct{}
-	HitAndRunsMutex sync.RWMutex
 
 	Torrents      map[string]*Torrent // SHA-1 hash (20 bytes)
 	TorrentsMutex sync.RWMutex

--- a/database/database.go
+++ b/database/database.go
@@ -116,7 +116,7 @@ func (db *Database) Init() {
 	db.bufferPool = util.NewBufferPool(maxBuffers, 128)
 
 	db.loadUsersStmt = db.mainConn.prepareStatement("SELECT ID, torrent_pass, DownMultiplier, UpMultiplier, DisableDownload FROM users_main WHERE Enabled='1'")
-	db.loadTorrentsStmt = db.mainConn.prepareStatement("SELECT ID, info_hash, DownMultiplier, UpMultiplier, Snatched, Status FROM torrents")
+    db.loadTorrentsStmt = db.mainConn.prepareStatement("SELECT t.ID ID, t.info_hash info_hash, (IFNULL(tg.DownMultiplier,1) * t.DownMultiplier) DownMultiplier, (IFNULL(tg.UpMultiplier,1) * t.UpMultiplier) UpMultiplier, t.Snatched Snatched, t.Status Status FROM torrents AS t LEFT JOIN torrent_group_freeleech AS tg ON tg.GroupID=t.GroupID AND (tg.Type=t.TorrentType OR (tg.Type='music' AND t.TorrentType='ost'))")
 	db.loadWhitelistStmt = db.mainConn.prepareStatement("SELECT peer_id FROM xbt_client_whitelist")
 	db.loadFreeleechStmt = db.mainConn.prepareStatement("SELECT mod_setting FROM mod_core WHERE mod_option='global_freeleech'")
 	db.cleanStalePeersStmt = db.mainConn.prepareStatement("UPDATE transfer_history SET active = '0' WHERE last_announce < ? AND active='1'")

--- a/database/database.go
+++ b/database/database.go
@@ -124,7 +124,7 @@ func (db *Database) Init() {
 	db.bufferPool = util.NewBufferPool(maxBuffers, 128)
 
 	db.loadUsersStmt = db.mainConn.prepareStatement("SELECT ID, torrent_pass, DownMultiplier, UpMultiplier, DisableDownload FROM users_main WHERE Enabled='1'")
-	db.loadHnrStmt = db.mainConn.prepareStatement("SELECT uid,fid FROM transfer_history WHERE hnr='1'")
+	db.loadHnrStmt = db.mainConn.prepareStatement("SELECT h.uid,h.fid FROM transfer_history AS h JOIN users_main AS u ON u.ID = h.uid WHERE hnr='1' AND Enabled='1'")
 	db.loadTorrentsStmt = db.mainConn.prepareStatement("SELECT t.ID ID, t.info_hash info_hash, (IFNULL(tg.DownMultiplier,1) * t.DownMultiplier) DownMultiplier, (IFNULL(tg.UpMultiplier,1) * t.UpMultiplier) UpMultiplier, t.Snatched Snatched, t.Status Status FROM torrents AS t LEFT JOIN torrent_group_freeleech AS tg ON tg.GroupID=t.GroupID AND (tg.Type=t.TorrentType OR (tg.Type='music' AND t.TorrentType='ost'))")
 	db.loadWhitelistStmt = db.mainConn.prepareStatement("SELECT peer_id FROM xbt_client_whitelist")
 	db.loadFreeleechStmt = db.mainConn.prepareStatement("SELECT mod_setting FROM mod_core WHERE mod_option='global_freeleech'")

--- a/database/database.go
+++ b/database/database.go
@@ -66,7 +66,7 @@ type User struct {
 	DisableDownload bool
 }
 
-type HitAndRun struct {
+type UserTorrentPair struct {
 	UserId    uint64
 	TorrentId uint64
 }
@@ -92,7 +92,7 @@ type Database struct {
 	Users      map[string]*User // 32 bytes
 	UsersMutex sync.RWMutex
 	
-	HitAndRuns      map[HitAndRun]bool
+	HitAndRuns      map[UserTorrentPair]struct{}
 	HitAndRunsMutex sync.RWMutex
 
 	Torrents      map[string]*Torrent // SHA-1 hash (20 bytes)
@@ -133,7 +133,7 @@ func (db *Database) Init() {
 	db.unPruneTorrentStmt = db.mainConn.prepareStatement("UPDATE torrents SET Status=0 WHERE ID = ?")
 
 	db.Users = make(map[string]*User)
-	db.HitAndRuns = make(map[HitAndRun]bool)
+	db.HitAndRuns = make(map[UserTorrentPair]struct{})
 	db.Torrents = make(map[string]*Torrent)
 	db.Whitelist = make([]string, 0, 100)
 

--- a/database/flush.go
+++ b/database/flush.go
@@ -170,7 +170,7 @@ func (db *Database) flushTransferHistory() {
 		query.Reset()
 
 		query.WriteString("INSERT INTO transfer_history (uid, fid, uploaded, downloaded, " +
-			"seeding, starttime, last_announce, seedtime, active, snatched, remaining) VALUES\n")
+			"seeding, starttime, last_announce, activetime, seedtime, active, snatched, remaining) VALUES\n")
 
 		for count = 0; count < length; count++ {
 			b := <-db.transferHistoryChannel
@@ -192,7 +192,8 @@ func (db *Database) flushTransferHistory() {
 		if count > 0 {
 			query.WriteString("\nON DUPLICATE KEY UPDATE uploaded = uploaded + VALUES(uploaded), " +
 				"downloaded = downloaded + VALUES(downloaded), connectable = VALUES(connectable), " +
-				"seeding = VALUES(seeding), seedtime = seedtime + VALUES(seedtime), last_announce = VALUES(last_announce), " +
+				"seeding = VALUES(seeding), activetime = activetime + VALUES(activetime), " +
+				"seedtime = seedtime + VALUES(seedtime), last_announce = VALUES(last_announce), " +
 				"active = VALUES(active), snatched = snatched + VALUES(snatched), remaining = VALUES(remaining);")
 
 			conn.execBuffer(&query)

--- a/database/record.go
+++ b/database/record.go
@@ -67,7 +67,7 @@ func (db *Database) RecordUser(user *User, rawDeltaUpload int64, rawDeltaDownloa
 	db.userChannel <- uq
 }
 
-func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload int64, rawDeltaDownload int64, deltaTime int64, deltaSnatch uint64, active bool) {
+func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload int64, rawDeltaDownload int64, deltaTime int64, deltaSeedTime int64, deltaSnatch uint64, active bool) {
 	th := db.bufferPool.Take() // ~110 bytes per record max
 
 	th.WriteString("('")
@@ -86,6 +86,8 @@ func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload int64, rawD
 	th.WriteString(strconv.FormatInt(peer.LastAnnounce, 10))
 	th.WriteString("','")
 	th.WriteString(strconv.FormatInt(deltaTime, 10))
+	th.WriteString("','")
+	th.WriteString(strconv.FormatInt(deltaSeedTime, 10))
 	th.WriteString("','")
 	th.WriteString(util.Btoa(active))
 	th.WriteString("','")

--- a/database/record.go
+++ b/database/record.go
@@ -67,7 +67,7 @@ func (db *Database) RecordUser(user *User, rawDeltaUpload int64, rawDeltaDownloa
 	db.userChannel <- uq
 }
 
-func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload int64, rawDeltaDownload int64, deltaTime int64, deltaSeedTime int64, deltaSnatch uint64, active bool) {
+func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload, rawDeltaDownload, deltaTime, deltaSeedTime int64, deltaSnatch uint64, active bool) {
 	th := db.bufferPool.Take() // ~110 bytes per record max
 
 	th.WriteString("('")

--- a/database/reload.go
+++ b/database/reload.go
@@ -140,9 +140,7 @@ func (db *Database) loadHitAndRuns() {
 	}
 	db.mainConn.mutex.Unlock()
 
-	db.HitAndRunsMutex.Lock()
 	db.HitAndRuns = newHnr
-	db.HitAndRunsMutex.Unlock()
 
 	log.Printf("Hit and run load complete (%d rows, %dms)", count, time.Now().Sub(start).Nanoseconds()/1000000)
 }

--- a/database/reload.go
+++ b/database/reload.go
@@ -110,13 +110,12 @@ func (db *Database) loadUsers() {
 func (db *Database) loadHitAndRuns() {
 	var err error
 	var count uint
-
-	db.HitAndRunsMutex.Lock()
+	
 	db.mainConn.mutex.Lock()
 	start := time.Now()
 	result := db.mainConn.query(db.loadHnrStmt)
 
-	newHnr := make(map[HitAndRun]bool)
+	newHnr := make(map[UserTorrentPair]struct{})
 
 	row := &rowWrapper{result.MakeRow()}
 
@@ -131,16 +130,17 @@ func (db *Database) loadHitAndRuns() {
 			log.Panicf("Error scanning hit and run rows: %v", err)
 		}
 
-		hnr := HitAndRun{
+		hnr := UserTorrentPair{
 			UserId: row.Uint64(uid),
 			TorrentId: row.Uint64(fid),
 		}
-		newHnr[hnr] = true
+		newHnr[hnr] = struct{}{}
 
 		count++
 	}
 	db.mainConn.mutex.Unlock()
 
+	db.HitAndRunsMutex.Lock()
 	db.HitAndRuns = newHnr
 	db.HitAndRunsMutex.Unlock()
 

--- a/server/announce.go
+++ b/server/announce.go
@@ -196,8 +196,10 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 	peer.Seeding = seeding
 
 	var deltaTime int64
+	deltaTime = now - peer.LastAnnounce
+	var deltaSeedTime int64
 	if seeding {
-		deltaTime = now - peer.LastAnnounce
+		deltaSeedTime = now - peer.LastAnnounce
 	}
 	peer.LastAnnounce = now
 	torrent.LastAction = now
@@ -259,7 +261,7 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 
 	// If the channels are already full, record* blocks until a flush occurs
 	db.RecordTorrent(torrent, deltaSnatch)
-	db.RecordTransferHistory(peer, rawDeltaUpload, rawDeltaDownload, deltaTime, deltaSnatch, active)
+	db.RecordTransferHistory(peer, rawDeltaUpload, rawDeltaDownload, deltaTime, deltaSeedTime, deltaSnatch, active)
 	db.RecordUser(user, rawDeltaUpload, rawDeltaDownload, deltaUpload, deltaDownload)
 	record(peer.TorrentId, user.Id, rawDeltaUpload, rawDeltaDownload, uploaded, event, ip)
 

--- a/server/announce.go
+++ b/server/announce.go
@@ -197,9 +197,17 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 
 	var deltaTime int64
 	deltaTime = now - peer.LastAnnounce
+	// too long, set delta to 0
+	if (deltaTime > 2*int64(config.AnnounceInterval.Seconds())) {
+		deltaTime = 0
+	}
 	var deltaSeedTime int64
 	if seeding {
 		deltaSeedTime = now - peer.LastAnnounce
+		// too long, set delta to 0
+		if (deltaSeedTime > 2*int64(config.AnnounceInterval.Seconds())) {
+			deltaSeedTime = 0
+		}
 	}
 	peer.LastAnnounce = now
 	torrent.LastAction = now

--- a/server/announce.go
+++ b/server/announce.go
@@ -59,9 +59,6 @@ func hasHitAndRun(db *cdb.Database, userId uint64, torrentId uint64) bool {
 		UserId: userId,
 		TorrentId: torrentId,
 	}
-
-	db.HitAndRunsMutex.RLock()
-	defer db.HitAndRunsMutex.Unlock()
 	_, exists := db.HitAndRuns[hnr]
 	return exists
 }


### PR DESCRIPTION
Better handle HnR for leeching torrents by:
  - keeping track of total active time in addition to seeding time
  - allowing user to download hit and runs even if download privileges are revoked 