### PR TITLE
Kuroneko

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ var (
 	TorrentFlushBufferSize         = 10000
 	UserFlushBufferSize            = 10000
 	TransferHistoryFlushBufferSize = 10000
-	TransferIpsFlushBufferSize     = 1000
+	TransferIpsFlushBufferSize     = 10000
 	SnatchFlushBufferSize          = 100
 )
 

--- a/database/database.go
+++ b/database/database.go
@@ -30,12 +30,14 @@ import (
 
 type Peer struct {
 	Id        string
+	ClientId  uint
 	UserId    uint64
 	TorrentId uint64
 
-	Port uint
-	Ip   string
-	Addr []byte
+	Port      uint
+	IpAddr    string
+	Ip        uint32
+	Addr      []byte
 
 	Uploaded   uint64
 	Downloaded uint64

--- a/database/database.go
+++ b/database/database.go
@@ -34,10 +34,10 @@ type Peer struct {
 	UserId    uint64
 	TorrentId uint64
 
-	Port      uint
-	IpAddr    string
-	Ip        uint32
-	Addr      []byte
+	Port   uint
+	IpAddr string
+	Ip     uint32
+	Addr   []byte
 
 	Uploaded   uint64
 	Downloaded uint64

--- a/database/flush.go
+++ b/database/flush.go
@@ -245,8 +245,7 @@ func (db *Database) flushTransferIps() {
 		}
 
 		if count > 0 {
-			query.WriteString("\nON DUPLICATE KEY UPDATE downloaded = downloaded + VALUES(ip), uploaded = uploaded + VALUES(uploaded), last_announce = VALUES(last_announce);")
-
+			query.WriteString("\nON DUPLICATE KEY UPDATE downloaded = downloaded + VALUES(downloaded), uploaded = uploaded + VALUES(uploaded), last_announce = VALUES(last_announce);")
 			conn.execBuffer(&query)
 
 			if length < (config.TransferIpsFlushBufferSize >> 1) {

--- a/database/flush.go
+++ b/database/flush.go
@@ -225,7 +225,7 @@ func (db *Database) flushTransferIps() {
 		length := util.Max(1, len(db.transferIpsChannel))
 		query.Reset()
 
-		query.WriteString("INSERT INTO transfer_ips (uid, fid, peer_id, starttime, ip, port) VALUES\n")
+		query.WriteString("INSERT INTO transfer_ips (uid, fid, client_id, ip, uploaded, downloaded, starttime, last_announce) VALUES\n")
 
 		for count = 0; count < length; count++ {
 			b := <-db.transferIpsChannel
@@ -245,7 +245,7 @@ func (db *Database) flushTransferIps() {
 		}
 
 		if count > 0 {
-			query.WriteString("\nON DUPLICATE KEY UPDATE ip = VALUES(ip), port = VALUES(port);")
+			query.WriteString("\nON DUPLICATE KEY UPDATE downloaded = downloaded + VALUES(ip), uploaded = uploaded + VALUES(uploaded), last_announce = VALUES(last_announce);")
 
 			conn.execBuffer(&query)
 

--- a/database/record.go
+++ b/database/record.go
@@ -99,21 +99,27 @@ func (db *Database) RecordTransferHistory(peer *Peer, rawDeltaUpload, rawDeltaDo
 	db.transferHistoryChannel <- th
 }
 
-func (db *Database) RecordTransferIp(peer *Peer) {
-	ti := db.bufferPool.Take() // ~95 bytes per record max
+func (db *Database) RecordTransferIp(peer *Peer, rawDeltaUpload int64, rawDeltaDownload int64) {
+	ti := db.bufferPool.Take() // ~40 bytes per record max
 
+	// used with:
+	// INSERT INTO transfer_ips (uid, fid, client_id, ip, uploaded, downloaded, starttime, last_announce)
 	ti.WriteString("('")
 	ti.WriteString(strconv.FormatUint(peer.UserId, 10))
 	ti.WriteString("','")
 	ti.WriteString(strconv.FormatUint(peer.TorrentId, 10))
 	ti.WriteString("','")
-	ti.WriteString(base64.StdEncoding.EncodeToString([]byte(peer.Id))) // ~30 bytes
+	ti.WriteString(strconv.FormatUint(peer.ClientId, 10))
 	ti.WriteString("','")
-	ti.WriteString(strconv.FormatInt(peer.StartTime, 10))
+	ti.WriteString(strconv.FormatUint(peer.Ip, 10))
 	ti.WriteString("','")
-	ti.WriteString(peer.Ip)
+	ti.WriteString(strconv.FormatInt(rawDeltaUpload, 10))
 	ti.WriteString("','")
-	ti.WriteString(strconv.FormatUint(uint64(peer.Port), 10))
+	ti.WriteString(strconv.FormatInt(rawDeltaDownload, 10))
+	ti.WriteString("','")
+	th.WriteString(strconv.FormatInt(peer.StartTime, 10))
+	ti.WriteString("','")
+	th.WriteString(strconv.FormatInt(peer.LastAnnounce, 10))
 	ti.WriteString("')")
 
 	db.transferIpsChannel <- ti

--- a/database/record.go
+++ b/database/record.go
@@ -19,7 +19,6 @@ package database
 
 import (
 	"chihaya/util"
-	"encoding/base64"
 	"strconv"
 )
 
@@ -109,17 +108,17 @@ func (db *Database) RecordTransferIp(peer *Peer, rawDeltaUpload int64, rawDeltaD
 	ti.WriteString("','")
 	ti.WriteString(strconv.FormatUint(peer.TorrentId, 10))
 	ti.WriteString("','")
-	ti.WriteString(strconv.FormatUint(peer.ClientId, 10))
+	ti.WriteString(strconv.FormatUint(uint64(peer.ClientId), 10))
 	ti.WriteString("','")
-	ti.WriteString(strconv.FormatUint(peer.Ip, 10))
+	ti.WriteString(strconv.FormatUint(uint64(peer.Ip), 10))
 	ti.WriteString("','")
 	ti.WriteString(strconv.FormatInt(rawDeltaUpload, 10))
 	ti.WriteString("','")
 	ti.WriteString(strconv.FormatInt(rawDeltaDownload, 10))
 	ti.WriteString("','")
-	th.WriteString(strconv.FormatInt(peer.StartTime, 10))
+	ti.WriteString(strconv.FormatInt(peer.StartTime, 10))
 	ti.WriteString("','")
-	th.WriteString(strconv.FormatInt(peer.LastAnnounce, 10))
+	ti.WriteString(strconv.FormatInt(peer.LastAnnounce, 10))
 	ti.WriteString("')")
 
 	db.transferIpsChannel <- ti

--- a/database/reload.go
+++ b/database/reload.go
@@ -230,7 +230,7 @@ func (db *Database) loadWhitelist() {
 	id := result.Map("id")
 	peer_id := result.Map("peer_id")
 
-	db.Whitelist = nil
+	db.Whitelist = make(map[uint32]string)
 
 	for {
 		err := result.ScanRow(row)

--- a/database/reload.go
+++ b/database/reload.go
@@ -227,6 +227,9 @@ func (db *Database) loadWhitelist() {
 
 	row := result.MakeRow()
 
+        id := result.Map("id")
+        peer_id := result.Map("peer_id")
+
 	db.Whitelist = nil
 
 	for {
@@ -236,7 +239,7 @@ func (db *Database) loadWhitelist() {
 		} else if err != nil {
 			log.Panicf("Error scanning whitelist rows: %v", err)
 		}
-		db.Whitelist = append(db.Whitelist, row.Str(0))
+		db.Whitelist[uint32(row.Uint64(id))] = row.Str(peer_id)
 	}
 	db.mainConn.mutex.Unlock()
 	db.WhitelistMutex.Unlock()

--- a/database/reload.go
+++ b/database/reload.go
@@ -227,8 +227,8 @@ func (db *Database) loadWhitelist() {
 
 	row := result.MakeRow()
 
-        id := result.Map("id")
-        peer_id := result.Map("peer_id")
+	id := result.Map("id")
+	peer_id := result.Map("peer_id")
 
 	db.Whitelist = nil
 

--- a/server/announce.go
+++ b/server/announce.go
@@ -79,7 +79,7 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 		return
 	}
 
-        client_id := whitelisted(peerId, db)
+	client_id := whitelisted(peerId, db)
 	if 0 == client_id {
 		failure("Your client is not approved", buf)
 		return
@@ -249,7 +249,7 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 	peer.Port = uint(port)
 	peer.IpAddr = ipAddr
 	peer.Ip = ip
-        peer.ClientId = client_id
+	peer.ClientId = client_id
 	var val byte
 	val = 0
 	k := 0

--- a/server/announce.go
+++ b/server/announce.go
@@ -107,7 +107,6 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 
 	// Optional parameters
 	event, _ := params.get("event")
-	shouldFlushAddr := false
 
 	var numWantStr string
 	var numWant int
@@ -365,7 +364,7 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 			for _, other := range peersToSend {
 				buf.WriteRune('d')
 				util.Bencode("ip", buf)
-				util.Bencode(other.ipAddr, buf)
+				util.Bencode(other.IpAddr, buf)
 				util.Bencode("peer id", buf)
 				util.Bencode(other.Id, buf)
 				util.Bencode("port", buf)

--- a/server/announce.go
+++ b/server/announce.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-func whitelisted(peerId string, db *cdb.Database) bool {
+func whitelisted(peerId string, db *cdb.Database) uint32 {
 	db.WhitelistMutex.RLock()
 	defer db.WhitelistMutex.RUnlock()
 
@@ -36,7 +36,7 @@ func whitelisted(peerId string, db *cdb.Database) bool {
 	var i int
 	var matched bool
 
-	for _, whitelistedId := range db.Whitelist {
+	for id, whitelistedId := range db.Whitelist {
 		widLen = len(whitelistedId)
 		if widLen <= len(peerId) {
 			matched = true
@@ -47,11 +47,11 @@ func whitelisted(peerId string, db *cdb.Database) bool {
 				}
 			}
 			if matched {
-				return true
+				return id 
 			}
 		}
 	}
-	return false
+	return 0
 }
 
 func hasHitAndRun(db *cdb.Database, userId uint64, torrentId uint64) bool {
@@ -79,7 +79,8 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 		return
 	}
 
-	if !whitelisted(peerId, db) {
+        client_id := whitelisted(peerId, db)
+	if 0 == client_id {
 		failure("Your client is not approved", buf)
 		return
 	}
@@ -248,6 +249,7 @@ func announce(params *queryParams, user *cdb.User, ipAddr string, ip uint32, db 
 	peer.Port = uint(port)
 	peer.IpAddr = ipAddr
 	peer.Ip = ip
+        peer.ClientId = client_id
 	var val byte
 	val = 0
 	k := 0

--- a/server/server.go
+++ b/server/server.go
@@ -204,11 +204,10 @@ func (handler *httpHandler) respond(r *http.Request, buf *bytes.Buffer) {
 		return
 	}
 	ip = ip.To4()
-	ip = binary.BigEndian.Uint32(ip)
 
 	switch action {
 	case "announce":
-		announce(params, user, ipAddr, ip, handler.db, buf)
+		announce(params, user, ipAddr, binary.BigEndian.Uint32(ip), handler.db, buf)
 		return
 	case "scrape":
 		scrape(params, handler.db, buf)

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"encoding/binary"
 )
 
 type httpHandler struct {
@@ -197,17 +196,10 @@ func (handler *httpHandler) respond(r *http.Request, buf *bytes.Buffer) {
 			}
 		}
 	}
-	
-	ip := net.ParseIP(ipAddr)
-	if ip == nil {
-		failure("Malformed IP address", buf)
-		return
-	}
-	ip = ip.To4()
 
 	switch action {
 	case "announce":
-		announce(params, user, ipAddr, binary.BigEndian.Uint32(ip), handler.db, buf)
+		announce(params, user, ipAddr, handler.db, buf)
 		return
 	case "scrape":
 		scrape(params, handler.db, buf)


### PR DESCRIPTION
Changed transfer_ips table schema to:

```
MariaDB [animebytes]> describe transfer_ips;
+---------------+------------+------+-----+---------+-------+
| Field         | Type       | Null | Key | Default | Extra |
+---------------+------------+------+-----+---------+-------+
| last_announce | int(11)    | NO   |     | 0       |       |
| starttime     | int(11)    | NO   |     | 0       |       |
| uid           | int(11)    | NO   | PRI | 0       |       |
| fid           | int(11)    | NO   | PRI | 0       |       |
| ip            | int(11)    | NO   | PRI | 0       |       |
| client_id     | int(11)    | NO   | PRI | 0       |       |
| uploaded      | bigint(20) | NO   |     | 0       |       |
| downloaded    | bigint(20) | NO   |     | 0       |       |
+---------------+------------+------+-----+---------+-------+
```
This was done in order to reduce the size of the table; it also adds further functionality, allowing to track raw uploaded/downloaded stats on a per-ip and per-torrent client basis for each user.

Tracker code updates were made to accommodate for this change. The IP address is converted to integer, and the client id is retrieved from the whitelist. 
